### PR TITLE
fix: Use HTTPS fallback URL in callback-v2 to prevent mixed content e…

### DIFF
--- a/src/app/auth/callback-v2/page.tsx
+++ b/src/app/auth/callback-v2/page.tsx
@@ -37,7 +37,7 @@ function AuthCallbackV2Content() {
         }
 
         // Exchange session for authentication data using secure API
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8081'}/oauth2/session/exchange`, {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'https://movie-tracker-api-production.up.railway.app'}/oauth2/session/exchange`, {
           method: 'POST',
           credentials: 'include', // Include HTTP-only cookies
           headers: {


### PR DESCRIPTION
…rrors

- Update callback-v2 to use HTTPS Railway URL as fallback instead of HTTP localhost
- Ensures consistent HTTPS usage across all API calls in production
- Prevents mixed content errors when NEXT_PUBLIC_API_URL is not set
- Matches pattern used in debug/oauth2 page

🤖 Generated with [Claude Code](https://claude.ai/code)