### PR TITLE
feat: Complete Letterboxd aesthetic overhaul for dashboard

### DIFF
--- a/src/components/dashboard/dashboard-layout.tsx
+++ b/src/components/dashboard/dashboard-layout.tsx
@@ -104,55 +104,207 @@ export function DashboardLayout({
     switch (activeTab) {
       case 'profile':
         return (
-          <>
-            <StatsOverview stats={stats} loading={loading} />
-            <FavoriteFilms
-              movies={favoriteMovies}
-              loading={loading}
-              onMovieClick={onMovieClick}
-            />
-            
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              <div>
-                <RecentActivity
-                  activities={recentActivity}
-                  loading={loading}
-                  onMovieClick={onMovieClick}
-                />
+          <div className="space-y-12">
+            {/* Favorite Films - Hero Section */}
+            <section className="">
+              <div className="flex items-center justify-between mb-6">
+                <div>
+                  <h2 className="text-sm font-medium text-letterboxd-text-muted uppercase tracking-widest mb-1">
+                    FAVORITE FILMS
+                  </h2>
+                  {favoriteMovies.length === 0 && (
+                    <p className="text-letterboxd-text-secondary text-sm">
+                      Don't forget to select your favorite films!
+                    </p>
+                  )}
+                </div>
+                {favoriteMovies.length > 0 && (
+                  <button className="text-sm text-letterboxd-text-secondary hover:text-letterboxd-accent transition-colors font-medium">
+                    ALL
+                  </button>
+                )}
               </div>
               
-              <div>
-                <section className="mb-8">
+              {favoriteMovies.length > 0 ? (
+                <div className="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 gap-3">
+                  {favoriteMovies.slice(0, 6).map((movie) => (
+                    <div key={movie.id} className="group cursor-pointer" onClick={() => onMovieClick?.(movie)}>
+                      <div className="aspect-[2/3] bg-letterboxd-card rounded-md overflow-hidden shadow-lg group-hover:shadow-2xl transition-all duration-300 group-hover:scale-105">
+                        {movie.posterPath ? (
+                          <img
+                            src={`https://image.tmdb.org/t/p/w342${movie.posterPath}`}
+                            alt={movie.title}
+                            className="w-full h-full object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-letterboxd-text-muted text-xs text-center p-2">
+                            {movie.title}
+                          </div>
+                        )}
+                        {movie.userRating && (
+                          <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
+                            <div className="absolute bottom-2 left-2">
+                              <div className="flex items-center space-x-1 text-letterboxd-orange">
+                                {[...Array(5)].map((_, i) => (
+                                  <svg key={i} className={`w-3 h-3 fill-current ${
+                                    i < movie.userRating! ? 'text-letterboxd-orange' : 'text-gray-600'
+                                  }`} viewBox="0 0 20 20">
+                                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                                  </svg>
+                                ))}
+                              </div>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="border-2 border-dashed border-letterboxd-border rounded-lg p-8 text-center">
+                  <p className="text-letterboxd-text-muted">No favorite films selected yet</p>
+                </div>
+              )}
+            </section>
+
+            {/* Two Column Layout */}
+            <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
+              {/* Left Column - Recent Likes */}
+              <div className="lg:col-span-8">
+                <section>
                   <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-lg font-semibold text-gray-300 uppercase tracking-wide">
+                    <h2 className="text-sm font-medium text-letterboxd-text-muted uppercase tracking-widest">
                       RECENT LIKES
                     </h2>
-                    {recentLikes.length > 0 && (
-                      <button className="text-sm text-gray-400 hover:text-gray-300 transition-colors">
-                        ALL →
-                      </button>
-                    )}
+                    <button className="text-sm text-letterboxd-text-secondary hover:text-letterboxd-accent transition-colors font-medium flex items-center space-x-1">
+                      <span>♥ ALL</span>
+                    </button>
                   </div>
                   
-                  <MovieGrid
-                    movies={recentLikes}
-                    columns={4}
-                    showRating={false}
-                    onMovieClick={onMovieClick}
-                    loading={loading}
-                    emptyMessage="No recent likes"
-                    posterSize="sm"
-                  />
+                  {recentLikes.length > 0 ? (
+                    <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-2">
+                      {recentLikes.slice(0, 8).map((movie) => (
+                        <div key={movie.id} className="group cursor-pointer" onClick={() => onMovieClick?.(movie)}>
+                          <div className="aspect-[2/3] bg-letterboxd-card rounded-sm overflow-hidden shadow-md group-hover:shadow-lg transition-all duration-200 group-hover:scale-105">
+                            {movie.posterPath ? (
+                              <img
+                                src={`https://image.tmdb.org/t/p/w154${movie.posterPath}`}
+                                alt={movie.title}
+                                className="w-full h-full object-cover"
+                                loading="lazy"
+                              />
+                            ) : (
+                              <div className="w-full h-full flex items-center justify-center text-letterboxd-text-muted text-xs text-center p-1">
+                                {movie.title}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-center py-8">
+                      <p className="text-letterboxd-text-muted">No recent likes</p>
+                    </div>
+                  )}
+                </section>
+              </div>
+
+              {/* Right Column - Stats & Activity */}
+              <div className="lg:col-span-4 space-y-8">
+                {/* Compact Stats */}
+                <section>
+                  <div className="bg-letterboxd-card rounded-lg p-4">
+                    <div className="grid grid-cols-2 gap-4 text-center">
+                      <div>
+                        <div className="text-xl font-bold text-letterboxd-text-primary">{stats.moviesWatched}</div>
+                        <div className="text-xs text-letterboxd-text-muted uppercase tracking-wide">Films</div>
+                      </div>
+                      <div>
+                        <div className="text-xl font-bold text-letterboxd-text-primary">{stats.moviesInWatchlist}</div>
+                        <div className="text-xs text-letterboxd-text-muted uppercase tracking-wide">Watchlist</div>
+                      </div>
+                      <div>
+                        <div className="text-xl font-bold text-letterboxd-text-primary">{stats.averageRating.toFixed(1)}</div>
+                        <div className="text-xs text-letterboxd-text-muted uppercase tracking-wide">Avg Rating</div>
+                      </div>
+                      <div>
+                        <div className="text-xl font-bold text-letterboxd-text-primary">{stats.thisMonthActivity}</div>
+                        <div className="text-xs text-letterboxd-text-muted uppercase tracking-wide">This Month</div>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Recent Activity */}
+                <section>
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-sm font-medium text-letterboxd-text-muted uppercase tracking-widest">
+                      DIARY
+                    </h2>
+                  </div>
+                  
+                  {recentActivity.length > 0 ? (
+                    <div className="space-y-3">
+                      {recentActivity.slice(0, 3).map((activity) => (
+                        <div key={activity.id} className="bg-letterboxd-card rounded-lg p-3 flex items-center space-x-3">
+                          <div className="text-xs text-letterboxd-text-muted bg-letterboxd-darker px-2 py-1 rounded font-mono">
+                            {activity.timestamp.getDate().toString().padStart(2, '0')}
+                            <div className="text-[10px] opacity-75">
+                              {activity.timestamp.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()}
+                            </div>
+                          </div>
+                          <div className="w-8 h-12 flex-shrink-0 cursor-pointer" onClick={() => onMovieClick?.(activity.movie)}>
+                            {activity.movie.posterPath ? (
+                              <img
+                                src={`https://image.tmdb.org/t/p/w92${activity.movie.posterPath}`}
+                                alt={activity.movie.title}
+                                className="w-full h-full object-cover rounded-sm"
+                              />
+                            ) : (
+                              <div className="w-full h-full bg-letterboxd-darker rounded-sm flex items-center justify-center">
+                                <span className="text-[8px] text-letterboxd-text-muted">?</span>
+                              </div>
+                            )}
+                          </div>
+                          <div className="flex-grow min-w-0">
+                            <button 
+                              onClick={() => onMovieClick?.(activity.movie)}
+                              className="font-medium text-letterboxd-text-primary hover:text-letterboxd-accent transition-colors text-sm block truncate w-full text-left"
+                            >
+                              {activity.movie.title}
+                            </button>
+                            {activity.rating && (
+                              <div className="flex items-center space-x-1 mt-1">
+                                {[...Array(5)].map((_, i) => (
+                                  <svg key={i} className={`w-2 h-2 fill-current ${
+                                    i < activity.rating! ? 'text-letterboxd-orange' : 'text-letterboxd-border'
+                                  }`} viewBox="0 0 20 20">
+                                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                                  </svg>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-center py-6">
+                      <p className="text-letterboxd-text-muted text-sm">No recent activity</p>
+                    </div>
+                  )}
                 </section>
               </div>
             </div>
-          </>
+          </div>
         )
       
       default:
         return (
           <div className="text-center py-12">
-            <p className="text-gray-400">
+            <p className="text-letterboxd-text-secondary">
               {activeTab.charAt(0).toUpperCase() + activeTab.slice(1)} content coming soon...
             </p>
           </div>
@@ -161,8 +313,8 @@ export function DashboardLayout({
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white">
-      <div className="max-w-7xl mx-auto px-4 py-8">
+    <div className="min-h-screen bg-letterboxd-dark-bg text-letterboxd-text-primary">
+      <div className="max-w-7xl mx-auto px-6 py-8">
         {/* Profile Header */}
         <ProfileHeader user={user} />
 
@@ -174,7 +326,7 @@ export function DashboardLayout({
         />
 
         {/* Content */}
-        <div className="space-y-8">
+        <div>
           {renderContent()}
         </div>
       </div>

--- a/src/components/dashboard/dashboard-tabs.tsx
+++ b/src/components/dashboard/dashboard-tabs.tsx
@@ -16,21 +16,21 @@ interface DashboardTabsProps {
 
 export function DashboardTabs({ activeTab, onTabChange, tabs }: DashboardTabsProps) {
   return (
-    <nav className="flex space-x-8 border-b border-gray-700 mb-8">
+    <nav className="flex space-x-8 border-b border-letterboxd-border mb-10">
       {tabs.map((tab) => (
         <button
           key={tab.id}
           onClick={() => onTabChange(tab.id)}
           className={clsx(
-            'pb-4 px-1 text-sm font-medium border-b-2 transition-colors',
+            'pb-4 px-1 text-sm font-medium border-b-2 transition-all duration-200 relative',
             activeTab === tab.id
-              ? 'text-green-400 border-green-400'
-              : 'text-gray-400 border-transparent hover:text-gray-300 hover:border-gray-600'
+              ? 'text-letterboxd-accent border-letterboxd-accent'
+              : 'text-letterboxd-text-muted border-transparent hover:text-letterboxd-text-secondary hover:border-letterboxd-border'
           )}
         >
           {tab.label}
           {tab.count !== undefined && (
-            <span className="ml-2 text-xs bg-gray-700 px-2 py-1 rounded-full">
+            <span className="ml-2 text-xs bg-letterboxd-card text-letterboxd-text-muted px-2 py-1 rounded-full">
               {tab.count}
             </span>
           )}

--- a/src/components/dashboard/profile-header.tsx
+++ b/src/components/dashboard/profile-header.tsx
@@ -18,50 +18,55 @@ interface ProfileHeaderProps {
 
 export function ProfileHeader({ user }: ProfileHeaderProps) {
   return (
-    <div className="flex flex-col md:flex-row items-start md:items-center gap-6 mb-8">
+    <div className="flex flex-col md:flex-row items-start md:items-center gap-6 mb-12">
       {/* Avatar and Basic Info */}
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-6">
         <UserAvatar 
           src={user.avatar}
           alt={user.username}
           size="xl"
           fallback={user.username}
+          className="ring-2 ring-letterboxd-border"
         />
-        <div className="space-y-2">
-          <h1 className="text-2xl font-bold text-white">
+        <div className="space-y-3">
+          <h1 className="text-3xl font-bold text-letterboxd-text-primary">
             {user.username}
           </h1>
-          <Button variant="outline" size="sm">
+          <Button 
+            variant="outline" 
+            size="sm"
+            className="border-letterboxd-border text-letterboxd-text-secondary hover:border-letterboxd-accent hover:text-letterboxd-accent bg-transparent text-xs font-medium tracking-wide"
+          >
             EDIT PROFILE
           </Button>
         </div>
       </div>
 
       {/* Stats */}
-      <div className="flex gap-8 ml-auto">
+      <div className="flex gap-12 ml-auto">
         <div className="text-center">
-          <div className="text-3xl font-bold text-white">
+          <div className="text-4xl font-bold text-letterboxd-text-primary mb-1">
             {user.stats.moviesWatched}
           </div>
-          <div className="text-sm text-gray-400 uppercase tracking-wide">
+          <div className="text-xs text-letterboxd-text-muted uppercase tracking-widest font-medium">
             FILMS
           </div>
         </div>
         
         <div className="text-center">
-          <div className="text-3xl font-bold text-white">
+          <div className="text-4xl font-bold text-letterboxd-text-primary mb-1">
             {user.stats.following}
           </div>
-          <div className="text-sm text-gray-400 uppercase tracking-wide">
+          <div className="text-xs text-letterboxd-text-muted uppercase tracking-widest font-medium">
             FOLLOWING
           </div>
         </div>
         
         <div className="text-center">
-          <div className="text-3xl font-bold text-white">
+          <div className="text-4xl font-bold text-letterboxd-text-primary mb-1">
             {user.stats.followers}
           </div>
-          <div className="text-sm text-gray-400 uppercase tracking-wide">
+          <div className="text-xs text-letterboxd-text-muted uppercase tracking-widest font-medium">
             FOLLOWERS
           </div>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,10 +42,17 @@ module.exports = {
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
         letterboxd: {
-          dark: '#14181c',
-          card: '#2c3440',
-          accent: '#00d735',
-          orange: '#ff8c00'
+          'dark-bg': '#14181c',
+          'darker': '#0e1115', 
+          'card': '#2c3440',
+          'card-hover': '#3c4450',
+          'accent': '#00d735',
+          'accent-hover': '#00c230',
+          'orange': '#ff8c00',
+          'text-primary': '#ffffff',
+          'text-secondary': '#9caea5',
+          'text-muted': '#678',
+          'border': '#456'
         }
       },
       borderRadius: {


### PR DESCRIPTION
- Transform dashboard with authentic Letterboxd dark theme (#14181c background)
- Redesign movie poster grids with proper aspect ratios and hover effects
- Add cinematic star ratings with orange Letterboxd-style stars
- Implement proper typography hierarchy matching Letterboxd design
- Create immersive dark layout with proper spacing and visual hierarchy
- Add movie poster prominence with larger favorite films section
- Redesign activity feed as compact diary-style entries with date badges
- Update color palette to match Letterboxd exactly (accent green, orange stars)
- Improve responsive grid layouts for movie collections
- Replace admin-style cards with cinematic dark panels

Transforms bland admin interface into rich movie-focused experience matching the original Letterboxd inspiration design.

🤖 Generated with [Claude Code](https://claude.ai/code)